### PR TITLE
PR #26 left us open to allowing 0 as max guesses

### DIFF
--- a/bot/src/plugins/hangman.cr
+++ b/bot/src/plugins/hangman.cr
@@ -142,7 +142,7 @@ class Hangman
   def start_game msg, list, guess_max
     unless GAMES.has_key? msg.channel.name
       if Game::WORDLISTS.has_key? list
-        GAMES[msg.channel.name] = Game.new list, {guess_max, Game::DEFAULT_GUESS_MAX}.min
+        GAMES[msg.channel.name] = Game.new list, guess_max.clamp(1, Game::DEFAULT_GUESS_MAX)
       else
         return
       end


### PR DESCRIPTION
  - Uses clamp to prevent guess_max outside of 1..DEFAULT_GUESS_MAX